### PR TITLE
feat: create docker image for icon cdn

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-webapp.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-webapp.md
@@ -1,0 +1,11 @@
+---
+name: Bug report icon-library
+about: Bug report for the SBB icons
+title: 'Bug report Icon: '
+assignees: '' 
+
+---
+
+* Which icon does the bug relate to? *
+
+* Describe the bug *

--- a/.github/ISSUE_TEMPLATE/feature-request-webapp.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-webapp.md
@@ -1,0 +1,10 @@
+---
+name: Feature request icon-library
+about: Suggest an idea for the SBB icons
+title: 'Feature Request Icon: '
+assignees: ''
+
+---
+
+**Describe the icon you'd like**
+A clear and concise description of what you want.

--- a/.github/default.conf
+++ b/.github/default.conf
@@ -1,0 +1,22 @@
+tcp_nopush          on;
+tcp_nodelay         on;
+types_hash_max_size 2048;
+
+server {
+  listen       8080 default_server;
+  server_name  _;
+  root         /usr/share/nginx/html;
+  index index.html index.htm;
+
+  location ~* \.(?:manifest|json)$ {
+    expires -1;
+  }
+
+  location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+    gzip_static on;
+    brotli_static on;
+    expires 10y;
+    access_log off;
+    add_header Cache-Control "public";
+  }
+}

--- a/.github/normalize-and-flatten-icons.js
+++ b/.github/normalize-and-flatten-icons.js
@@ -1,0 +1,91 @@
+const fs = require('fs');
+const path = require('path');
+
+if (require.main === module) {
+  const root = process.cwd();
+
+  const namespaces = fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+
+  const icons = [];
+  for (const namespace of namespaces) {
+    const namespaceRoot = path.join(root, namespace);
+    for (const file of walk(namespaceRoot)) {
+      const name = path
+        .basename(file, '.svg')
+        .replace(/^sbb_/, '')
+        .replace(/_/g, '-');
+      const tags = path.relative(root, path.dirname(file)).split('/');
+      fs.renameSync(file, path.join(namespaceRoot, `${name}.svg`));
+      icons.push({ name, namespace, tags });
+    }
+  }
+
+  fs.writeFileSync(
+    path.join(root, 'index.json'),
+    JSON.stringify(icons),
+    'utf8'
+  );
+
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+  <title>SBB Icon CDN</title>
+  <style type="text/css">
+    body {
+      display: flex;
+      flex-wrap: wrap;
+    }
+    a {
+      color: black;
+      margin: 0.5rem;
+      text-align: center;
+      text-decoration: none;
+      width: 25rem;
+    }
+    table {
+      text-align: left;
+    }
+  </style>
+</head>
+<body>
+${icons
+  .map(
+    (i) => `<a href="${i.namespace}/${i.name}.svg">
+  <img src="${i.namespace}/${i.name}.svg">
+  <table>
+    <tr>
+      <th>Name</th>
+      <td>${i.name}</td>
+    </tr>
+    <tr>
+      <th>Namespace</th>
+      <td>${i.namespace}</td>
+    </tr>
+  </table>
+</a>
+`
+  )
+  .join('\n')}
+</body>
+</html>
+`;
+  fs.writeFileSync(
+    path.join(root, 'index.html'),
+    html,
+    'utf8'
+  );
+}
+
+function walk(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).reduce((files, entry) => {
+    if (entry.isFile()) {
+      files.push(path.join(dir, entry.name));
+    } else if (entry.isDirectory()) {
+      files.push(...walk(path.join(dir, entry.name)));
+    }
+    return files;
+  }, []);
+}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,0 +1,26 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Docker: Parse release version"
+      id: docker_release_version
+      run: echo ::set-output name=docker_release_version::${GITHUB_REF/refs\/tags\//}
+    - name: "Build: Docker image"
+      run: |
+        docker build \
+        -t docker.pkg.github.com/$GITHUB_REPOSITORY/icon-cdn:${{ steps.docker_release_version.outputs.docker_release_version }} \
+        -t docker.pkg.github.com/$GITHUB_REPOSITORY/icon-cdn:latest \
+        .
+    - name: "Publish: Docker image"
+      run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/icon-cdn:${{ steps.docker_release_version.outputs.docker_release_version }}
+    - name: "Publish: Remove previous latest image, due to GitHub docker registry being immutable"
+      run: docker rmi docker.pkg.github.com/$GITHUB_REPOSITORY/icon-cdn:latest || true
+    - name: "Publish: Docker image as latest"
+      run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/icon-cdn:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,87 @@
+# This Dockerfile creates the icon CDN, which is be hosted on icons.app.sbb.ch (AWS Cluster).
+# It flattens all svg icons into a "namespace" folder, removes the sbb_ prefix from FPL icons and replaces all _ with -.
+# (e.g.
+#   icons/svg/FPL/Attribut/sbb_sa_1.svg => fpl/sa-1.svg
+#   icons/svg/KOM/responsive/large/010_Basic/calendar_large.svg => kom/calendar-large.svg)
+# It also creates the following:
+#  - Compressed variants of the icons (brotli, gzip), which will be served to compatible browsers.
+#  - An index.html with all icons
+#  - An index.json with all icons and additional information
+
+FROM nginx:1.18.0-alpine AS nginx-builder
+
+# Compiling NGINX module: https://gist.github.com/hermanbanken/96f0ff298c162a522ddbba44cad31081
+# nginx:alpine contains NGINX_VERSION environment variable, like so:
+# ENV NGINX_VERSION 1.15.0
+
+# Our BROTLI version
+ENV BROTLI_VERSION 1.0.0rc
+
+# Download sources
+RUN wget "http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" -O nginx.tar.gz
+
+# For latest build deps, see https://github.com/nginxinc/docker-nginx/blob/master/mainline/alpine/Dockerfile
+RUN apk add --no-cache --virtual .build-deps \
+  gcc \
+  libc-dev \
+  make \
+  openssl-dev \
+  pcre-dev \
+  zlib-dev \
+  linux-headers \
+  libxslt-dev \
+  gd-dev \
+  geoip-dev \
+  perl-dev \
+  libedit-dev \
+  mercurial \
+  bash \
+  alpine-sdk \
+  findutils \
+  git
+
+# Reuse same cli arguments as the nginx:alpine image used to build
+RUN CONFARGS=$(nginx -V 2>&1 | sed -n -e 's/^.*arguments: //p') \
+  CONFARGS=${CONFARGS/-Os -fomit-frame-pointer/-Os} && \
+  mkdir /usr/src && \
+	tar -zxC /usr/src -f nginx.tar.gz && \
+  git clone https://github.com/eustas/ngx_brotli.git && \
+  BROTLIDIR="$(pwd)/ngx_brotli" && \
+  cd ngx_brotli && \
+  git submodule update --init && \
+  cd /usr/src/nginx-$NGINX_VERSION && \
+  ./configure --with-compat $CONFARGS --add-dynamic-module=$BROTLIDIR && \
+  make modules && \
+  mv ./objs/*.so /
+
+FROM alpine:latest AS icons-builder
+
+WORKDIR /usr/icons
+
+RUN apk add --no-cache brotli gzip nodejs
+
+# Copy js script to create namespace index json
+COPY ./.github/normalize-and-flatten-icons.js normalize-and-flatten-icons.js
+
+# Copy FPL icons, remove sbb_ prefix and rename _ to -
+COPY ./icons/svg/FPL fpl
+COPY ./icons/svg/KOM/responsive kom
+
+# Normalize and flatten icons and create index
+RUN node ./normalize-and-flatten-icons.js fpl
+
+# Create compressed variants of the icons
+RUN brotli -k --best */*.svg
+RUN gzip -k --best */*.svg
+
+FROM nginxinc/nginx-unprivileged:1.18.0-alpine
+
+# Extract the dynamic module BROTLI from the nginx-builder image
+COPY --from=nginx-builder /ngx_http_brotli_static_module.so /etc/nginx/modules/ngx_http_brotli_static_module.so
+# Extract the icons from the icons-builder image
+COPY --from=icons-builder /usr/icons /usr/share/nginx/html
+
+# Copy nginx configuration
+COPY ./.github/default.conf /etc/nginx/conf.d/default.conf
+
+RUN sed -i 's,events {,load_module modules/ngx_http_brotli_static_module.so;\n\nevents {,' /etc/nginx/nginx.conf

--- a/HOW_TO_RELEASE.md
+++ b/HOW_TO_RELEASE.md
@@ -1,0 +1,45 @@
+# How to release
+This repository uses [Conventional Commits](https://www.conventionalcommits.org/) to generate the changelog.
+See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+To create the releases, [standard-version](https://www.npmjs.com/package/standard-version) will be used.
+(For a detailled documentation, see https://www.npmjs.com/package/standard-version#cli-usage)
+
+## Setup Release Tools
+
+1. Install [NodeJS](https://nodejs.org/)
+2. Open a console and run `npm install --global standard-version`
+
+## First release
+1. Open a console and navigate to repo root (`cd /path/to/repo`)
+2. Checkout master branch or other stable branch (`git checkout master` or `git checkout {branch}`)
+3. Git pull (`git pull`)
+4. Execute `standard-version --first-release`  
+   This will create the CHANGELOG.md file, commit it with the message `chore(release): 1.0.0` and create the git tag `v1.0.0`
+5. Run `git push --follow-tags origin master` to publish the release (commit and tag) to GitHub
+
+## Release
+1. Open a console and navigate to repo root (`cd /path/to/repo`)
+2. Checkout master branch or other stable branch (`git checkout master` or `git checkout {branch}`)
+3. Git pull (`git pull`)
+4. Execute `standard-version`  
+   This will update the CHANGELOG.md file, commit it with the message `chore(release): {version}` and create the git tag `v{version}`  
+
+   `{version}` will be a major version increase (e.g. 1.1.0 => 2.0.0), if a previous commit since the last release contains a BREAKING CHANGE in the description  
+   `{version}` will be a minor version increase (e.g. 1.1.0 => 1.2.0), if a previous commit message since the last release starts with `feat` (e.g. `feat: feature description` or `feat(scope): feature description`)  
+   `{version}` will be a patch version increase (e.g. 1.1.0 => 1.1.1), if the above rules are not met
+5. Run `git push --follow-tags origin master` to publish the release (commit and tag) to GitHub
+
+## Prerelease
+1. Open a console and navigate to repo root (`cd /path/to/repo`)
+2. Checkout master branch or other stable branch (`git checkout master` or `git checkout {branch}`)
+3. Git pull (`git pull`)
+4. Execute `standard-version --prerelease beta`
+   This will update the CHANGELOG.md file, commit it with the message `chore(release): {version}-beta.{count}` and create the git tag `v{version}-beta.{count}`   
+
+   `{version}` will NOT CHANGE, if the previous release was also a prerelease  
+   `{version}` will be a major version increase (e.g. 1.1.0 => 2.0.0), if a previous commit since the last release contains a BREAKING CHANGE in the description  
+   `{version}` will be a minor version increase (e.g. 1.1.0 => 1.2.0), if a previous commit message since the last release starts with `feat` (e.g. `feat: feature description` or `feat(scope): feature description`)  
+   `{version}` will be a patch version increase (e.g. 1.1.0 => 1.1.1), if the above rules are not met  
+   `{count}` will be `0` or an increment of the last prerelease, if the last release was a prerelease (e.g. 1.1.0-beta.0 => 1.1.0-beta.1
+5. Run `git push --follow-tags origin master` to publish the release (commit and tag) to GitHub

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -1,0 +1,60 @@
+# Process
+
+1. Select an [issue](https://github.com/sbb-design-systems/icon-library/issues) that you want to work on
+2. Checkout master branch
+3. Pull changes
+4. Create new branch with appropriate name (prefix `feat-` for features or prefix `fix-` for fixes)
+5. Do your changes
+6. Commit your changes while following the [commit message guidelines](#commit)
+7. Push your changes to [origin](https://github.com/sbb-design-systems/icon-library)
+8. Create a pull request (PR) with your pushed branch (in [GitHub](https://github.com/sbb-design-systems/icon-library))
+  8.1. Optionally select reviewers for your PR
+9. When ok/accepted, `Squash and merge` the PR
+10. Delete the branch
+
+
+## <a name="commit"></a> Commit Message Guidelines
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) to generate the changelog.
+
+### Commit Message Format
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+Any line of the commit message cannot be longer than 100 characters! This allows the message to be easier
+to read on GitHub as well as in various git tools.
+
+### Type
+Must be one of the following:
+
+* **feat**: A new feature
+* **fix**: A bug fix
+* **docs**: Documentation only changes
+
+### Scope
+The scope could be anything specifying place of the commit change. For example
+`kom`, `fpl`
+
+### Subject
+The subject contains succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize first letter
+* no dot (.) at the end
+
+### Body
+Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
+The body should include the motivation for the change and contrast this with previous behavior.
+
+### Footer
+The footer should contain any information about **Breaking Changes** and is also the place to
+reference GitHub issues that this commit **Closes**.
+
+**Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines.
+The rest of the commit message is then used for this.
+
+**Close issue**. Want to close some issue with the commit use the word `Closes` with a space and the issue number (e.g. Closes #39).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# SBB Design System Icon Library
+
+This is the repository for the [icons](https://digital.sbb.ch/en/brand_elemente/icons) of the SBB design systems.
+
+Feel free to open an [issue](https://github.com/sbb-design-systems/icon-library/issues/new/choose) if you have a feature request or just a question.
+
+## <a name="issue"></a> Found an Issue?
+If you find a bug in the design system documentation or a mistake in the sketch library file, you can help us by
+[submitting an issue](#submit-issue) to our [GitHub Repository](https://github.com/sbb-design-systems/icon-library). Including an issue reproduction is the
+absolute best way to help the team quickly diagnose the problem. Screenshots are also helpful.
+
+
+## <a name="feature"></a> Want a new Feature?
+You can *request* a new feature (new component, module or a new characteristic of one of them) by
+[submitting an issue](#submit-issue) to our [GitHub Repository](https://github.com/sbb-design-systems/icon-library). 
+
+
+## <a name="submit-issue"></a> Submitting an Issue
+If your issue appears to be a bug or a new feature, and hasn't been reported, open a new issue.
+You can file new issues by providing the above information [here](https://github.com/sbb-design-systems/icon-library/issues/new/choose).


### PR DESCRIPTION
This Dockerfile creates the icon CDN, which is be hosted on icons.app.sbb.ch (AWS Cluster).
It flattens all svg icons into a "namespace" folder, removes the sbb_ prefix from FPL icons and replaces all _ with -.
(e.g.
  icons/svg/FPL/Attribut/sbb_sa_1.svg => fpl/sa-1.svg
  icons/svg/KOM/responsive/large/010_Basic/calendar_large.svg => kom/calendar-large.svg)
It also creates the following:
 - Compressed variants of the icons (brotli, gzip), which will be served to compatible browsers.
 - An index.html with all icons
 - An index.json with all icons and additional information